### PR TITLE
Add Gir.Node methods to easily get attribute values

### DIFF
--- a/src/gir/metadata/matcher.vala
+++ b/src/gir/metadata/matcher.vala
@@ -22,6 +22,9 @@
  * that match the metadata rules.
  */
 public class Gir.Metadata.Matcher {
+
+    public const string ATTRIBUTE_PREFIX = "dev.vala.";
+    
     /**
      * The Gir Context
      */
@@ -95,16 +98,19 @@ public class Gir.Metadata.Matcher {
 
     // Create a gir <attribute> element in the provided gir nodes
     private void create_attributes (Gee.List<Gir.Node> nodes, string key, string? val) {
+        // prefix the attribute name with a qualifier
+        string name = ATTRIBUTE_PREFIX + key;
+        
         foreach (var node in nodes) {
             if (node is InfoElements) {
                 var info_elements = (InfoElements) node;
-                info_elements.attributes.add (new Attribute (key, val, null));
+                info_elements.attributes.add (new Attribute (name, val, null));
             } else if (node is Parameter) {
                 var parameter = (Parameter) node;
-                parameter.attributes.add (new Attribute (key, val, null));
+                parameter.attributes.add (new Attribute (name, val, null));
             } else if (node is Namespace) {
                 var ns = (Namespace) node;
-                ns.attributes.add (new Attribute (key, val, null));
+                ns.attributes.add (new Attribute (name, val, null));
             }
         }
     }

--- a/src/gir/node.vala
+++ b/src/gir/node.vala
@@ -66,8 +66,11 @@ public abstract class Gir.Node : Object {
      * requested name, otherwise return false
      */
     public bool has_attribute (string name) {
+        // prefix the attribute name with the qualifier used for vala attributes
+        string qualified_name = Gir.Metadata.Matcher.ATTRIBUTE_PREFIX + name;
+
         foreach (Attribute attr in get_attributes ()) {
-            if (attr.name == name) {
+            if (attr.name == qualified_name) {
                 return true;
             }
         }
@@ -81,8 +84,11 @@ public abstract class Gir.Node : Object {
      * `null`, or the requested attribute is not found.
      */
     public string? get_attribute (string name) {
+        // prefix the attribute name with the qualifier used for vala attributes
+        string qualified_name = Gir.Metadata.Matcher.ATTRIBUTE_PREFIX + name;
+
         foreach (Attribute attr in get_attributes ()) {
-            if (attr.name == name) {
+            if (attr.name == qualified_name) {
                 return attr.value == "()" ? null : attr.value;
             }
         }

--- a/src/gir/node.vala
+++ b/src/gir/node.vala
@@ -60,4 +60,49 @@ public abstract class Gir.Node : Object {
 
         return sb.str;
     }
+
+    /**
+     * Return true when this node contains an `<attribute>` element with the
+     * requested name, otherwise return false
+     */
+    public bool has_attribute (string name) {
+        foreach (Attribute attr in get_attributes ()) {
+            if (attr.name == name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return the value of the `<attribute>` element with the requested name.
+     * Return `null` when the value is equal to `()`, or the attribute value is
+     * `null`, or the requested attribute is not found.
+     */
+    public string? get_attribute (string name) {
+        foreach (Attribute attr in get_attributes ()) {
+            if (attr.name == name) {
+                return attr.value == "()" ? null : attr.value;
+            }
+        }
+
+        return null;
+    }
+
+    /* Get all `<attribute>` elements of this Gir node. When there are none, an
+     * empty list is returned. */
+    private Gee.List<Attribute> get_attributes () {
+        if (this is InfoElements) {
+            return ((InfoElements) this).attributes;
+        } else if (this is Namespace) {
+            return ((Namespace) this).attributes;
+        } else if (this is Parameter) {
+            return ((Parameter) this).attributes;
+        } else if (this is ReturnValue) {
+            return ((ReturnValue) this).attributes;
+        } else {
+            return new Gee.ArrayList<Attribute> ();
+        }
+    }
 }


### PR DESCRIPTION
This PR adds two public methods to the Gir.Node base class:
- `public bool has_attribute(string name)`
- `public string? get_attribute(string name)`

(And a private helper method.)

This can be used to apply the metadata when generating a VAPI, for example:

```vala
// generate vala symbol from the gir data
vala_sym.foo = gir_node.foo;

// is "foo" overridden in metadata?
if (gir_node.has_attribute ("foo") {
    vala_sym.foo = gir_node.get_attribute ("foo");
}
```

Without these helper methods, we would have to iterate trough the List of Attribute elements every time.