### PR TITLE
Apply metadata rules

### DIFF
--- a/src/gir/node.vala
+++ b/src/gir/node.vala
@@ -60,4 +60,49 @@ public abstract class Gir.Node : Object {
 
         return sb.str;
     }
+
+    /**
+     * Return true when this node contains an `<attribute>` element with the
+     * requested name, otherwise return false
+     */
+    public bool has_attribute (string name) {
+        foreach (Attribute attr in get_attributes ()) {
+            if (attr.name == name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Return the value of the `<attribute>` element with the requested name.
+     * Return `null` when the value is equal to `()`, or the attribute value is
+     * `null`, or the requested attribute is not found.
+     */
+    public string? get_attribute (string name) {
+        foreach (Attribute attr in get_attributes ()) {
+            if (attr.name == name) {
+                return attr.value == "()" ? null : attr.value;
+            }
+        }
+
+        return null;
+    }
+
+    /* Get all `<attribute>` elements of this Gir node. When there are none, an
+     * empty list is returned. */
+    private Gee.List<Attribute> get_attributes () {
+        if (this is InfoElements) {
+            return ((InfoElements) this).attributes;
+        } else if (this is Namespace) {
+            return ((Namespace) this).attributes;
+        } else if (this is Parameter) {
+            return ((Parameter) this).attributes;
+        } else if (this is ReturnValue) {
+            return ((ReturnValue) this).attributes;
+        } else {
+            return new Gee.ArrayList<Attribute> ();
+        }
+    }
 }


### PR DESCRIPTION
This PR is a first attempt to apply a couple metadata rules to the generated vapi.
So far I've added the following rules:
- type
- type_arguments
- skip
- introspectable
- hidden
- cheader_filename
- compact
- new
- printf_format

The "skip", "introspectable" and "hidden" rules are all used to prevent a gir element from being included in the generated vapi. To simplify this, I added a `private static bool skip(Gir.Node node)` method that will return `true` when the element is either skipped, not introspectable, or hidden.

The "type" and "type_arguments" rules override the gir `<type>` element with a Vala datatype. This is applied in the `DatatypeBuilder` class.

The other metadata rules are added in the relevant places; for example the `printf_format` attribute is added when applying InfoAttrs to a callable (i.e. a method, function, constructor, etc).

This PR uses the helper functions of PR #4 .